### PR TITLE
Update CNES Report and CNES Scan version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,9 @@ ADD https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/v1.2.0/so
     /opt/sonarqube/extensions/plugins/
 
 # CNES report installation
-ADD https://github.com/lequal/sonar-cnes-report/releases/download/v1.1.0/sonar-report-cnes.jar \
-    https://github.com/lequal/sonar-cnes-report/releases/download/v1.1.0/issues-template.xlsx \
-    https://github.com/lequal/sonar-cnes-report/releases/download/v1.1.0/code-analysis-template.docx \
+ADD https://github.com/lequal/sonar-cnes-report/releases/download/2.1.0/cnesreport.jar \
+    https://github.com/lequal/sonar-cnes-report/releases/download/2.1.0/issues-template.xlsx \
+    https://github.com/lequal/sonar-cnes-report/releases/download/2.1.0/code-analysis-template.docx \
     /opt/sonar/extensions/cnes/
 
 # Sonar scanner installation

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir /opt/sonar
 COPY ./conf /tmp/conf  
 
 # Download Sonarqubes plugins.
-ADD https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/v1.2.0/sonar-cnes-scan-plugin-1.2.jar \
+ADD https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/v1.3.0/sonar-cnes-scan-plugin-1.3.jar \
     https://github.com/checkstyle/sonar-checkstyle/releases/download/3.7/checkstyle-sonar-plugin-3.7.jar \
     https://github.com/lequal/sonar-cnes-cxx-plugin/releases/download/v1.1.0/sonar-cnes-cxx-plugin-1.1.jar \
     https://github.com/lequal/sonar-cnes-export-plugin/releases/download/v1.1.0/sonar-cnes-export-plugin-1.1.jar \

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Once the container is active, use the [Sonar CNES Scan plugin](https://github.co
   - python-setuptools *latest*
 
 ## SonarQube extensions
-- Sonar CNES Report 1.1
+- Sonar CNES Report 2.1.0
 
 ## SonarQube plugins
 - Checkstyle sonar plugin 3.7
 - Sonar CNES CXX plugin 1.1
 - Sonar CNES Export plugin 1.1
 - Sonar CNES Python plugin 1.1
-- Sonar CNES Scan plugin 1.2
+- Sonar CNES Scan plugin 1.3
 - Sonar Corbetura plugin 1.9.1
 - Sonar C# plugin 6.1.0.2359
 - Sonar CXX plugin 0.9.7


### PR DESCRIPTION
In order to Fix #16, we need to upgrade to the last version of CNES Report (2.1.0).
We also need to update the Sonar CNES Scan Plugin to use the new call parameters of the CNES Report tool.

This is an upgrade for these two tools included in Docker CAT : 
- 1.2 -> 1.3 for Sonar CNES Scan Plugin : https://github.com/lequal/sonar-cnes-scan-plugin/releases/tag/v1.3.0
- 1.1.0 -> 2.1.0 for CNES Report tool : https://github.com/lequal/sonar-cnes-report/releases/tag/2.1.0 