### PR TITLE
Update docker-cat based on CAT 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,6 @@ script:
   - echo "Waiting few seconds while docker is starting"
   - sleep 30
   - docker ps -a
+  - docker logs cat
   - docker exec cat frama-c --help
   - docker exec cat shellcheck --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ services:
   - docker
 
 script:
-  - docker build -t lequal/docker-cat .
+  - docker build -t cat-travis .
+  - docker image list
   - mkdir shared
   - chmod 777 shared
-  - docker run -d -v shared:/media/Sf_Shared -p 9000:9000 -p 9001:9001 --name cat lequal/docker-cat
+  - docker run -d -v shared:/media/Sf_Shared -p 9000:9000 -p 9001:9001 --name cat cat-travis
   - echo "Waiting few seconds while docker is starting"
   - sleep 30
   - docker ps -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,11 @@ services:
 
 script:
   - docker build -t lequal/docker-cat .
-
+  - mkdir shared
+  - chmod 777 shared
+  - docker run -d -v shared:/media/Sf_Shared -p 9000:9000 -p 9001:9001 --name cat lequal/docker-cat
+  - echo "Waiting few seconds while docker is starting"
+  - sleep 30
+  - docker ps -a
+  - docker exec cat frama-c --help
+  - docker exec cat shellcheck --help

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ script:
   - chmod 777 shared
   - docker run -d -v shared:/media/Sf_Shared -p 9000:9000 -p 9001:9001 --name cat cat-travis
   - echo "Waiting few seconds while docker is starting"
-  - sleep 30
+  - sleep 300
   - docker ps -a
   - docker logs cat
-  - docker exec cat frama-c --help
-  - docker exec cat shellcheck --help
+  - docker exec cat shellcheck -V
+  - docker exec cat frama-c -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN mkdir /opt/sonar
 COPY ./conf /tmp/conf
 
 # Download Sonarqubes plugins.
-ADD https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/v1.3.0/sonar-cnes-scan-plugin-1.3.jar \
-    https://github.com/checkstyle/sonar-checkstyle/releases/download/3.7/checkstyle-sonar-plugin-3.7.jar \
+ADD https://github.com/checkstyle/sonar-checkstyle/releases/download/3.7/checkstyle-sonar-plugin-3.7.jar \
     https://github.com/lequal/sonar-cnes-cxx-plugin/releases/download/v1.1.0/sonar-cnes-cxx-plugin-1.1.jar \
     https://github.com/lequal/sonar-cnes-export-plugin/releases/download/v1.1.0/sonar-cnes-export-plugin-1.1.jar \
     https://github.com/lequal/sonar-cnes-python-plugin/releases/download/1.1/sonar-cnes-python-plugin-1.1.jar \
@@ -32,13 +31,17 @@ ADD https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/v1.3.0/so
     https://binaries.sonarsource.com/Distribution/sonar-typescript-plugin/sonar-typescript-plugin-1.1.0.1079.jar \
     https://binaries.sonarsource.com/Distribution/sonar-web-plugin/sonar-web-plugin-2.5.0.476.jar \
     https://binaries.sonarsource.com/Distribution/sonar-xml-plugin/sonar-xml-plugin-1.4.3.1027.jar \
+    ## TMP: For dev -- switch to release when merged
+    https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/untagged-5dd2f88d9fac5868c85c/sonar-cnes-scan-plugin-1.4.jar \
     /opt/sonarqube/extensions/plugins/
 
+
+
 # CNES report installation
-## TODO: REMOVE CNES REPORT
-ADD https://github.com/lequal/sonar-cnes-report/releases/download/2.1.0/cnesreport.jar \
-    https://github.com/lequal/sonar-cnes-report/releases/download/2.1.0/issues-template.xlsx \
-    https://github.com/lequal/sonar-cnes-report/releases/download/2.1.0/code-analysis-template.docx \
+ADD https://github.com/lequal/sonar-cnes-report/releases/download/2.2.0/sonar-cnes-report.jar \
+    /opt/sonarqube/extensions/plugins/cnesreport.jar
+ADD https://github.com/lequal/sonar-cnes-report/releases/download/2.2.0/issues-template.xlsx \
+    https://github.com/lequal/sonar-cnes-report/releases/download/2.2.0/code-analysis-template.docx \
     /opt/sonar/extensions/cnes/
 
 
@@ -138,6 +141,9 @@ RUN opam install frama-c -y
 ## ====================== CONFIGURATION STAGE ===============================
 
 FROM apt-stage AS final-configuration-stage
+ENV SONAR_RUNNER_HOME=/opt/sonar-scanner
+ENV PATH $PATH:/opt/sonar-scanner
+ENV HOME /opt/sonarqube
 USER root
 # Make sonarqube owner of it's installation directories
 RUN chown sonarqube:sonarqube -R /opt \

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ADD https://github.com/checkstyle/sonar-checkstyle/releases/download/3.7/checkst
     https://binaries.sonarsource.com/Distribution/sonar-web-plugin/sonar-web-plugin-2.5.0.476.jar \
     https://binaries.sonarsource.com/Distribution/sonar-xml-plugin/sonar-xml-plugin-1.4.3.1027.jar \
     ## TMP: For dev -- switch to release when merged
-    https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/untagged-5dd2f88d9fac5868c85c/sonar-cnes-scan-plugin-1.4.jar \
+    https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/1.4.0/sonar-cnes-scan-plugin-1.4.jar \
     /opt/sonarqube/extensions/plugins/
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,14 +115,14 @@ RUN tar -xzvf rats-2.4.tgz \
 RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/*
 
 #Install shellcheck
-RUN apt install shellcheck -y
+RUN apt update && apt install shellcheck -y
 
 
 
 
 ## ====================== BUILD FRAMA-C STAGE ===============================
 #Build with same base as sornaqube
-FROM debian:buster-slim AS build-frama-c
+FROM sonarqube:6.7.7-community AS build-frama-c
 USER root
 #Install frama-c
 RUN apt update
@@ -148,7 +148,8 @@ RUN chown sonarqube:sonarqube -R /opt \
 
 
 # Install frama-c
-COPY --from=build-frama-c /root/.opam/system/bin/* /usr/bin
+COPY --from=build-frama-c /root/.opam/system/bin/ /usr/bin
+RUN  ls /usr/bin
 
 
 # Entry point files

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,4 +163,6 @@ COPY ./configure-cat.bash /tmp/
 COPY ./init.bash /tmp/
 RUN chmod 750 /tmp/init.bash
 WORKDIR $SONARQUBE_HOME
+RUN chown sonarqube:sonarqube /tmp/init.bash
+USER sonarqube
 ENTRYPOINT ["/tmp/init.bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 ## ====================== DOWNLOAD DEPENDENCIES STAGE ===============================
 
-FROM sonarqube:6.7.7-community AS download-stage
+FROM sonarqube:6.7.4 AS download-stage
 ENV SONAR_RUNNER_HOME=/opt/sonar-scanner
 ENV PATH $PATH:/opt/sonar-scanner
 ENV HOME /opt/sonarqube
-USER root
 RUN mkdir /opt/sonar
 COPY ./conf /tmp/conf
 
@@ -14,25 +13,24 @@ ADD https://github.com/checkstyle/sonar-checkstyle/releases/download/3.7/checkst
     https://github.com/lequal/sonar-cnes-export-plugin/releases/download/v1.1.0/sonar-cnes-export-plugin-1.1.jar \
     https://github.com/lequal/sonar-cnes-python-plugin/releases/download/1.1/sonar-cnes-python-plugin-1.1.jar \
     https://github.com/lequal/sonar-icode-cnes-plugin/releases/download/1.1.0/sonaricode-1.1.0.jar \
-    https://github.com/lequal/sonar-frama-c-plugin/releases/download/V2.0.0/sonarframac-2.0.0.jar \
     https://github.com/galexandre/sonar-cobertura/releases/download/1.9.1/sonar-cobertura-plugin-1.9.1.jar \
     https://github.com/SonarSource/sonar-csharp/releases/download/6.1.0.2359/sonar-csharp-plugin-6.1.0.2359.jar \
-    https://github.com/SonarOpenCommunity/sonar-cxx/releases/download/cxx-0.9.7/sonar-cxx-plugin-0.9.7.jar \
+    https://github.com/SonarOpenCommunity/sonar-cxx/releases/download/cxx-1.1.0/sonar-cxx-plugin-1.1.0.jar \
     https://github.com/spotbugs/sonar-findbugs/releases/download/3.7.0/sonar-findbugs-plugin-3.7.0.jar \
-    https://binaries.sonarsource.com/Distribution/sonar-flex-plugin/sonar-flex-plugin-2.4.0.1222.jar \
+    https://binaries.sonarsource.com/Distribution/sonar-flex-plugin/sonar-flex-plugin-2.5.1.1831.jar \
     https://binaries.sonarsource.com/Distribution/sonar-java-plugin/sonar-java-plugin-5.4.0.14284.jar \
     https://binaries.sonarsource.com/Distribution/sonar-javascript-plugin/sonar-javascript-plugin-3.1.1.5128.jar \
     https://binaries.sonarsource.com/Distribution/sonar-php-plugin/sonar-php-plugin-2.10.0.2087.jar \
     https://binaries.sonarsource.com/Distribution/sonar-pmd-plugin/sonar-pmd-plugin-2.5.jar \
-    https://binaries.sonarsource.com/Distribution/sonar-python-plugin/sonar-python-plugin-1.8.0.1496.jar \
+    https://binaries.sonarsource.com/Distribution/sonar-python-plugin/sonar-python-plugin-1.14.0.3086.jar \
     https://github.com/willemsrb/sonar-rci-plugin/releases/download/sonar-rci-plugin-1.0.1/sonar-rci-plugin-1.0.1.jar \
-    https://binaries.sonarsource.com/Distribution/sonar-scm-git-plugin/sonar-scm-git-plugin-1.2.jar \
-    https://binaries.sonarsource.com/Distribution/sonar-scm-svn-plugin/sonar-scm-svn-plugin-1.4.0.522.jar \
-    https://binaries.sonarsource.com/Distribution/sonar-typescript-plugin/sonar-typescript-plugin-1.1.0.1079.jar \
+    https://binaries.sonarsource.com/Distribution/sonar-scm-git-plugin/sonar-scm-git-plugin-1.8.0.1574.jar \
+    https://binaries.sonarsource.com/Distribution/sonar-scm-svn-plugin/sonar-scm-svn-plugin-1.8.0.1168.jar \
+    https://binaries.sonarsource.com/Distribution/sonar-typescript-plugin/sonar-typescript-plugin-1.9.0.3766.jar \
     https://binaries.sonarsource.com/Distribution/sonar-web-plugin/sonar-web-plugin-2.5.0.476.jar \
     https://binaries.sonarsource.com/Distribution/sonar-xml-plugin/sonar-xml-plugin-1.4.3.1027.jar \
-    ## TMP: For dev -- switch to release when merged
     https://github.com/lequal/sonar-cnes-scan-plugin/releases/download/1.4.0/sonar-cnes-scan-plugin-1.4.jar \
+    https://github.com/lequal/sonar-frama-c-plugin/releases/download/V2.0.0/sonarframac-2.0.0.jar \
     /opt/sonarqube/extensions/plugins/
 
 
@@ -44,29 +42,15 @@ ADD https://github.com/lequal/sonar-cnes-report/releases/download/2.2.0/issues-t
     https://github.com/lequal/sonar-cnes-report/releases/download/2.2.0/code-analysis-template.docx \
     /opt/sonar/extensions/cnes/
 
-
-# I-Code
-ADD https://github.com/lequal/i-CodeCNES/releases/download/v3.1.0/i-CodeCNES-3.1.0-CLI-linux.gtk.x86_64.zip /tmp
-RUN unzip /tmp/i-CodeCNES-3.1.0-CLI-linux.gtk.x86_64.zip -d /tmp;chmod +x /tmp/icode/icode;mv /tmp/icode/* /usr/bin
-RUN rm -r /tmp/icode
-RUN rm /tmp/i-CodeCNES-3.1.0-CLI-linux.gtk.x86_64.zip
-
-## ====================== APT / INSTALLATIONS STAGE ===============================
-
-FROM download-stage AS apt-stage
-ENV SONAR_RUNNER_HOME=/opt/sonar-scanner
-ENV PATH $PATH:/opt/sonar-scanner
-ENV HOME /opt/sonarqube
-USER root
+# Download softwares
+ADD https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rough-auditing-tool-for-security/rats-2.4.tgz \
+    http://downloads.sourceforge.net/project/expat/expat/2.0.1/expat-2.0.1.tar.gz \
+    https://github.com/lequal/i-CodeCNES/releases/download/v3.1.0/i-CodeCNES-3.1.0-CLI-linux.gtk.x86_64.zip \
+    /tmp/
 
 # Sonar scanner installation
 ADD https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip \
     /tmp/scanners/
-
-RUN apt update && apt install -y unzip apt-utils && rm -rf /var/lib/apt/lists/* \
-    && unzip /tmp/scanners/sonar-scanner-cli-3.0.3.778-linux.zip -d /opt/ \
-    && mv /opt/sonar-scanner-3.0.3.778-linux /opt/sonar-scanner \
-    && rm -rf /tmp/scanners
 
 
 # Python, Pylint and CNES pylint setup
@@ -81,7 +65,18 @@ ADD https://github.com/tartley/colorama/archive/v0.3.3.tar.gz \
     https://github.com/lequal/cnes-pylint-extension/archive/V1.0.tar.gz \
     /tmp/python/
 
-RUN apt update && apt install -y python-setuptools && rm -rf /var/lib/apt/lists/* \
+
+RUN apt update && apt install unzip python-setuptools cppcheck vera\+\+ gcc make jq shellcheck -y\
+    && rm -rf /var/lib/apt/lists/* \
+    #Install i-code
+    && unzip /tmp/i-CodeCNES-3.1.0-CLI-linux.gtk.x86_64.zip -d /tmp;chmod +x /tmp/icode/icode;mv /tmp/icode/* /usr/bin \
+    && rm -r /tmp/icode \
+    && rm /tmp/i-CodeCNES-3.1.0-CLI-linux.gtk.x86_64.zip \
+    ## Install sonar scanner
+    && unzip /tmp/scanners/sonar-scanner-cli-3.0.3.778-linux.zip -d /opt/ \
+    && mv /opt/sonar-scanner-3.0.3.778-linux /opt/sonar-scanner \
+    && rm -rf /tmp/scanners \
+    ## Python, Pylin et CNES pylint setup
     && mkdir /opt/python \
     && find /tmp/python -maxdepth 1 -name \*.tar.gz -exec tar -xvzf {} -C /opt/python \; \
     && ls /opt/python \
@@ -91,78 +86,52 @@ RUN apt update && apt install -y python-setuptools && rm -rf /var/lib/apt/lists/
     && cd /opt/python/wrapt-1.10.5/ && python setup.py install \
     && cd /opt/python/astroid-astroid-1.4.9/ && python setup.py install \
     && cd /opt/python/pylint-pylint-1.5/ && python setup.py install \
-    && rm -rf /tmp/python
-
-# C and C++ tools installation
-WORKDIR /tmp
-## CPPCheck, gcc, make, vera++
-RUN apt update && apt install -y cppcheck vera\+\+ gcc make && rm -rf /var/lib/apt/lists/*
-
-## Expat, rats
-ADD http://downloads.sourceforge.net/project/expat/expat/2.0.1/expat-2.0.1.tar.gz /tmp/
-RUN tar -xvzf expat-2.0.1.tar.gz \
+    && rm -rf /tmp/python \
+    ## C and C++ tools installation
+    && cd /tmp && tar -xvzf expat-2.0.1.tar.gz \
     && cd expat-2.0.1 \
     && ./configure && make && make install \
     && cd .. \
-    && rm -rf ./expat-2.0.1.tar.gz ./expat-2.0.1
-
-ADD https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/rough-auditing-tool-for-security/rats-2.4.tgz /tmp/
-RUN tar -xzvf rats-2.4.tgz \
+    && rm -rf ./expat-2.0.1.tar.gz ./expat-2.0.1 \
+    && tar -xzvf rats-2.4.tgz \
     && cd rats-2.4 \
     && ./configure --with-expat-lib=/usr/local/lib && make && make install \
     && ./rats \
     && cd .. \
     && rm -rf ./rats-2.4.tgz ./rats-2.4
 
-# jq required for configure-cat script.
-RUN apt update && apt install -y jq && rm -rf /var/lib/apt/lists/*
-
-#Install shellcheck
-RUN apt update && apt install shellcheck -y
-
-
-
-
-## ====================== BUILD FRAMA-C STAGE ===============================
-#Build with same base as sornaqube
-FROM sonarqube:6.7.7-community AS build-frama-c
-USER root
-#Install frama-c
-RUN apt update
-RUN apt install opam graphviz libgnomecanvas2-dev pkg-config -y
-RUN opam init -y; opam update
-RUN opam install depext -y
-RUN opam depext conf-autoconf.0.1 -y
-RUN opam depext conf-gmp.1 -y
-RUN opam depext conf-gtksourceview.2 -y
-RUN opam install frama-c -y
+## Install frama-c
+## Need to be installed after, this script resolve mannualy dependencies and fix a python bug
+## which generate an error when dpkg try to configure python.
+RUN rm /usr/local/lib/libexpat.so.1 \
+    && apt update \
+    && apt install opam autoconf debianutils libgmp-dev libgtksourceview2.0-dev pkg-config graphviz libgnomecanvas2-dev -y; rm /usr/local/lib/libexpat.so.1 \
+    && dpkg --configure -a \
+    && opam init -y; opam update; opam install frama-c -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /opt/sonarqube/.opam/system/bin/frama-c /bin/frama-c
 
 
 ## ====================== CONFIGURATION STAGE ===============================
 
-FROM apt-stage AS final-configuration-stage
-ENV SONAR_RUNNER_HOME=/opt/sonar-scanner
-ENV PATH $PATH:/opt/sonar-scanner
-ENV HOME /opt/sonarqube
-USER root
-# Make sonarqube owner of it's installation directories
-RUN chown sonarqube:sonarqube -R /opt \
-    && ls -lrta /opt/ \
-    && chown sonarqube:sonarqube -R /home \
-    && ls -lrta /home/ \
-    && chown sonarqube:sonarqube -R /tmp/conf
+FROM download-stage AS configuration-stage
 
 
-# Install frama-c
-COPY --from=build-frama-c /root/.opam/system/bin/ /usr/bin
-RUN  ls /usr/bin
+
 
 
 # Entry point files
 COPY ./configure-cat.bash /tmp/
 COPY ./init.bash /tmp/
-RUN chmod 750 /tmp/init.bash
+
+# Make sonarqube owner of it's installation directories
+RUN chown sonarqube:sonarqube -R /opt \
+    && ls -lrta /opt/ \
+    && chmod 750 /tmp/init.bash \
+    && chown sonarqube:sonarqube -R /home \
+    && ls -lrta /home/ \
+    && chown sonarqube:sonarqube -R /tmp/conf \
+    && ln -s /opt/sonarqube/extensions/plugins/ /opt/sonar/extensions/plugins
+
 WORKDIR $SONARQUBE_HOME
-RUN chown sonarqube:sonarqube /tmp/init.bash
-USER sonarqube
 ENTRYPOINT ["/tmp/init.bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,7 +135,7 @@ RUN chown sonarqube:sonarqube -R /opt \
     && chown sonarqube:sonarqube -R /tmp/conf \
     && ln -s /opt/sonarqube/extensions/plugins/ /opt/sonar/extensions/plugins \
     && mkdir -p /opt/sonarqube/frama-c/ \
-    && root@5c0462e329d4:/tmp# ln -s /bin/frama-c /opt/sonarqube/frama-c/frama-c
+    && ln -s /bin/frama-c /opt/sonarqube/frama-c/frama-c
 
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["/tmp/init.bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,10 +104,9 @@ RUN apt update && apt install unzip python-setuptools cppcheck vera\+\+ gcc make
 ENV HOME /home/sonarqube
 RUN rm /usr/local/lib/libexpat.so.1 \
     && apt update \
-    && apt install autoconf debianutils libgmp-dev libgtksourceview2.0-dev pkg-config graphviz libgnomecanvas2-dev -y; rm /usr/local/lib/libexpat.so.1 \
+    && apt install opam autoconf debianutils libgmp-dev libgtksourceview2.0-dev pkg-config graphviz libgnomecanvas2-dev -y; rm /usr/local/lib/libexpat.so.1 \
     && dpkg --configure -a \
-    && sh <(curl -sL https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh) \\
-    && opam update; opam install frama-c -y \
+    && opam init -y; opam update; opam install frama-c -y \
     && ln -s /home/sonarqube/.opam/system/bin/frama-c /bin/frama-c \
     && apt remove opam -y \
     && apt autoremove -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,9 @@ RUN rm /usr/local/lib/libexpat.so.1 \
     && dpkg --configure -a \
     && opam init -y; opam update; opam install frama-c -y \
     && rm -rf /var/lib/apt/lists/* \
-    && ln -s /opt/sonarqube/.opam/system/bin/frama-c /bin/frama-c
+    && ln -s /opt/sonarqube/.opam/system/bin/frama-c /bin/frama-c \
+    && apt remove opam -y \
+    && apt autoremove -y
 
 
 ## ====================== CONFIGURATION STAGE ===============================
@@ -131,7 +133,9 @@ RUN chown sonarqube:sonarqube -R /opt \
     && chown sonarqube:sonarqube -R /home \
     && ls -lrta /home/ \
     && chown sonarqube:sonarqube -R /tmp/conf \
-    && ln -s /opt/sonarqube/extensions/plugins/ /opt/sonar/extensions/plugins
+    && ln -s /opt/sonarqube/extensions/plugins/ /opt/sonar/extensions/plugins \
+    && mkdir -p /opt/sonarqube/frama-c/ \
+    && root@5c0462e329d4:/tmp# ln -s /bin/frama-c /opt/sonarqube/frama-c/frama-c
 
 WORKDIR $SONARQUBE_HOME
 ENTRYPOINT ["/tmp/init.bash"]

--- a/init.bash
+++ b/init.bash
@@ -50,6 +50,5 @@ allow_sonarqube &
 wait %1
 # Call for configure-cat script to set quality profiles and quality gates.
 bash /tmp/configure-cat.bash &
-#sudo -u sonarqube exec ${SONARQUBE_HOME}/bin/run.sh
 su sonarqube
-exec "${SONARQUBE_HOME}/bin/run.sh"
+exec ${SONARQUBE_HOME}/bin/run.sh

--- a/init.bash
+++ b/init.bash
@@ -2,12 +2,12 @@
 
 ########################################################
 # init.bash
-# 
-# IMPORTANT : 
+#
+# IMPORTANT :
 # This file is intended to run be run while running SonarQube on the docker image "docker-cat".
 # This file should be run as an ENTRYPOINT of docker's image. If you re-use the docker-cat image, call this file inside your entrypoint.
-# The Dockerfile docker-cat inherit Sonarqube 6.7.1 image. This script run Sonarqube's entrypoint.
-# 
+# The Dockerfile docker-cat inherit Sonarqube 6.7.7 image. This script run Sonarqube's entrypoint.
+#
 # Description :
 # This file configure Sonarqube, also, it's perform permissions modifications to allow CNES scanner to involve in the project (creating sonar-properties files, etc...).
 #
@@ -18,7 +18,7 @@ sonar_configuration="INIT"
 ########################################################
 # function allow_sonarqube
 #
-# Description : 
+# Description :
 # For each GID specified in the env variable ALLOWED_GROUPS, create a new group
 # siwht the specified GID and then add it to Sonarqube.
 ################################################################################
@@ -42,7 +42,7 @@ allow_sonarqube(){
     else
       echo "[INFO] Docker-cat could not find any specified permission for Sonarqube. Use allow-group command to set new ones."
     fi
-	
+
     echo "[INFO] Docker-cat permissions for sonarqube finished."
 }
 
@@ -50,5 +50,6 @@ allow_sonarqube &
 wait %1
 # Call for configure-cat script to set quality profiles and quality gates.
 bash /tmp/configure-cat.bash &
+#sudo -u sonarqube exec ${SONARQUBE_HOME}/bin/run.sh
 su sonarqube
-exec ${SONARQUBE_HOME}/bin/run.sh
+exec "${SONARQUBE_HOME}/bin/run.sh"


### PR DESCRIPTION
This version is the last version with SonarQube 6.7LTS. The next one should use SonarQube 7.9LTS

It includes some tools and prepare upgrade to SonarQube 7.9LTS.

## Changelog
- [New] Install ShellCheck
- [New] Install Frama-C
- [Update] Sonar plugins updated
- [Update] Cnes-report and cnes-scan are ready for sonarqube 7
- [Update] I-Code plugin updated + add CLI interface
- [New] More Integration test 

Dockerfile is also rewrited to optimize size (reduce number of layers)